### PR TITLE
Favorite destroy

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ I see text saying that I have no favorited pets
 ```
 
 ```
-[ ] done
+[X] done
 
 User Story 15, Remove all Favorite from Favorites Page
 

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ And I also see that my favorites indicator has decremented by 1
 ```
 
 ```
-[ ] done
+[X] done
 
 User Story 13, Remove a Favorite from Favorites Page
 

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -2,9 +2,7 @@ class FavoritesController < ApplicationController
 
   def index
     if favorite.pets != nil
-      @fav_pet_objects = favorite.pets.map do |pet_id|
-        Pet.find(pet_id)
-      end
+      @fav_pet_objects = favorite.pet_objects
     else
     end
   end

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -15,7 +15,7 @@ class FavoritesController < ApplicationController
     @pet = Pet.find(params[:pet_id])
     favorite.toggle(@pet.id)
     flash[:notice] = "Pet has been removed from favorites list."
-    redirect_to :back
+    redirect_back(fallback_location:"/favorites")
   end
 
 end

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,7 +1,10 @@
 class FavoritesController < ApplicationController
 
   def index
-    @fav_pet_objects = favorite.pet_objects if favorite.pets != nil
+    if favorite.pets != nil
+      @fav_pet_objects = favorite.pet_objects
+    else
+    end
   end
 
   def create
@@ -15,7 +18,7 @@ class FavoritesController < ApplicationController
     @pet = Pet.find(params[:pet_id])
     favorite.toggle(@pet.id)
     flash[:notice] = "Pet has been removed from favorites list."
-    redirect_to :back
+    redirect_to "/pets/#{@pet.id}"
   end
 
 end

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -18,4 +18,9 @@ class FavoritesController < ApplicationController
     redirect_back(fallback_location:"/favorites")
   end
 
+  def destroy_all
+    favorite.pets.clear
+    redirect_back(fallback_location:"/favorites")
+  end
+
 end

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,10 +1,7 @@
 class FavoritesController < ApplicationController
 
   def index
-    if favorite.pets != nil
-      @fav_pet_objects = favorite.pet_objects
-    else
-    end
+    @fav_pet_objects = favorite.pet_objects if favorite.pets != nil
   end
 
   def create
@@ -18,7 +15,7 @@ class FavoritesController < ApplicationController
     @pet = Pet.find(params[:pet_id])
     favorite.toggle(@pet.id)
     flash[:notice] = "Pet has been removed from favorites list."
-    redirect_to "/pets/#{@pet.id}"
+    redirect_to :back
   end
 
 end

--- a/app/controllers/shelters_controller.rb
+++ b/app/controllers/shelters_controller.rb
@@ -56,6 +56,5 @@ class SheltersController < ApplicationController
   private
   def shelter_params
     params.permit(:name, :address, :city, :state, :zip)
-    # params.require(:shelters).permit(:name, :address, :city, :state, :zip)
   end
 end

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -20,5 +20,11 @@ class Favorite
       add_pet(id)
     end
   end
-  
+
+  def pet_objects
+    @pets.map do |pet_id|
+      Pet.find(pet_id)
+    end
+  end
+
 end

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -5,7 +5,7 @@
 
   <section id='pets-index'>
 
-    <% if @fav_pet_objects != nil %>
+    <% if @fav_pet_objects != [] %>
       <% @fav_pet_objects.each do |pet| %>
         <div class='pet-card'>
           <%= image_tag(pet.image, alt: "photo of pet", method: :get) %>

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -1,6 +1,7 @@
 <main>
   <section class='page-header'>
     <h2 class='page-title'>Favorite Pets</h2>
+    <%= link_to 'Remove All Pets', "/favorites", method: :delete %>
   </section>
 
   <section id='pets-index'>

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -15,6 +15,9 @@
             <p><%= pet.approx_age %> year(s), <%= pet.sex %></p>
             <p><%= link_to "#{pet.shelter.name}", "/shelters/#{pet.shelter.id}", class: 'pet-shelter' %></p>
           </div>
+          <div class='options'>
+            <%= link_to 'Remove', "/favorites/#{pet.id}", method: :delete %>
+          </div>
         </div>
       <% end %>
     <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,5 +29,6 @@ Rails.application.routes.draw do
   post '/favorites/:pet_id', to: 'favorites#create'
   get '/favorites', to: 'favorites#index'
   delete '/favorites/:pet_id', to: 'favorites#destroy'
+  delete '/favorites', to: 'favorites#destroy_all'
 
 end

--- a/spec/features/favorites/index_spec.rb
+++ b/spec/features/favorites/index_spec.rb
@@ -32,5 +32,20 @@ RSpec.describe "as a visitor", type: :feature do
         expect(page).to have_content('Favorites')
       end
     end
+
+    it 'each pet has a link to remove from favorites, which redirects to /favorites' do
+
+      visit "/pets/#{@pet1.id}"
+      click_on 'Add pet to favorites'
+      visit "/favorites"
+
+      within(".pet-card") do
+        expect(page).to have_link("Remove")
+        click_on "Remove"
+      end
+
+      expect(current_path).to eq("/favorites")
+      expect(page).to_not have_content("Noodle")
+    end
   end
 end

--- a/spec/features/favorites/index_spec.rb
+++ b/spec/features/favorites/index_spec.rb
@@ -47,5 +47,24 @@ RSpec.describe "as a visitor", type: :feature do
       expect(current_path).to eq("/favorites")
       expect(page).to_not have_content("Noodle")
     end
+
+    it 'has a link to remove all favorite pets at once' do
+      pet2 = Pet.create(name: 'Yoda', approx_age: 6, sex: "male", description: "description of yoda", image: "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/13001403/Australian-Cattle-Dog-On-White-03.jpg", shelter_id: @shelter.id, status: "adoptable" )
+
+      visit "/pets/#{@pet1.id}"
+      click_on 'Add pet to favorites'
+
+      visit "/pets/#{pet2.id}"
+      click_on 'Add pet to favorites'
+
+      visit "/favorites"
+
+      click_on 'Remove All Pets'
+
+      expect(current_path).to eq("/favorites")
+      expect(page).to_not have_content("Noodle")
+      expect(page).to_not have_content("Yoda")
+
+    end
   end
 end


### PR DESCRIPTION
Completed stories 13 and 15. 

- story 13 asks for a 'remove' link on each pet in the favorites index page, but wants it to route to the same #destroy action that the other remove link (from the pets show page) routes to, BUT, it wants the action to redirect to the favorites index this time. **I solved this by using `redirect_back` instead of `redirect_to`.** 

- Story 15 wanted a 'remove all pets' link on the favorites page. 
- all tests pass

@NickEdwin 