### PR TITLE
Application index

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ I see a message saying that there are no applications for this pet yet
 ```
 
 ```
-[/] done
+[X] done
 
 User Story 22, Approving an Application
 

--- a/README.md
+++ b/README.md
@@ -404,7 +404,7 @@ And I see text on the page that says who this pet is on hold for (Ex: "On hold f
 ```
 
 ```
-[ ] done
+[X] done
 
 User Story 23, Users can get approved to adopt more than one pet
 
@@ -424,12 +424,14 @@ When a pet has more than one application made for them
 And one application has already been approved for them
 I can not approve any other applications for that pet but all other applications still remain on file (they can be seen on the pets application index page)
 (This can be done by either taking away the option to approve the application, or having a flash message pop up saying that no more applications can be approved for this pet at this time)
+
+# I think this story will require having a 'status' column added to the Applications Table that we can change/toggle with 'update'
 ```
 
 ```
 User Story 25, Approved Applications can be revoked
 
-[ ] done
+[X] done
 
 As a visitor
 After an application has been approved for a pet

--- a/app/assets/stylesheets/main.css
+++ b/app/assets/stylesheets/main.css
@@ -97,7 +97,7 @@ main {
   justify-content: space-between;
   align-items: baseline;
   padding-bottom: 8px;
-	margin: 10px 0px 30px 0px;
+	margin: 10px 0px 20px 0px;
   color: #9900CC;
   /* border-bottom: 1px solid #ddd; */
 }
@@ -154,6 +154,7 @@ main {
   justify-content: flex-start;
   flex-wrap: wrap;
   height: auto;
+	margin-bottom: 30px;
 }
 
 .pet-card {
@@ -281,6 +282,43 @@ main {
 	margin-top: 20px;
 }
 
+#pet-apps {
+	margin: 40px 0 30px 0;
+	padding-top: 10px;
+	border-top: 1px solid #ddd;
+}
+
+#pet-apps .app {
+	margin-left: 30px;
+}
+
+#pet-apps .app {
+	margin-bottom: 10px;
+}
+
+#pet-apps .app .app-name:hover {
+	color: #9900CC;
+}
+
 #flash-alert {
 	background-color: red;
+}
+
+footer {
+	margin: 100px 0 50px 0px;
+	padding-top: 20px;
+	border-top: 1px solid #ddd;
+	width: 60%;
+	display: flex;
+	justify-content: flex-start;
+	align-self: center;
+}
+
+footer small {
+	display: block;
+	width: 70%;
+	text-align: left;
+	font-style: italic;
+	font-size: .8em;
+	line-height: 20px;
 }

--- a/app/assets/stylesheets/main.css
+++ b/app/assets/stylesheets/main.css
@@ -359,6 +359,12 @@ main {
 	background-color: red;
 }
 
+#on-hold {
+	/* font-style: italic; */
+	color: #777;
+	margin-bottom: 20px;
+}
+
 footer {
 	margin: 100px 0 50px 0px;
 	padding-top: 20px;

--- a/app/assets/stylesheets/main.css
+++ b/app/assets/stylesheets/main.css
@@ -355,6 +355,10 @@ main {
 	color: #777;
 }
 
+#app-index .app-names {
+	margin-bottom: 20px;
+}
+
 #flash-alert {
 	background-color: red;
 }

--- a/app/assets/stylesheets/main.css
+++ b/app/assets/stylesheets/main.css
@@ -317,6 +317,23 @@ main {
 	color: #9900CC;
 }
 
+#app-index {
+	margin: 20px 0 30px 0;
+	padding-top: 10px;
+}
+
+#app-index .list {
+	margin-left: 30px;
+}
+
+#app-index .list {
+	margin-bottom: 10px;
+}
+
+#app-index .list .list-name:hover {
+	color: #9900CC;
+}
+
 .pet-list {
   width: 100%;
   display: flex;

--- a/app/assets/stylesheets/main.css
+++ b/app/assets/stylesheets/main.css
@@ -133,10 +133,10 @@ main {
 	margin: 0 0 0 0px;
 }
 
-.options a {
+.shelter .options a {
   font-size: .8em;
   opacity: 70%;
-	margin-right: 10px;
+	/* margin-right: 10px; */
 }
 
 .options a:hover {
@@ -147,6 +147,7 @@ main {
 	font-size: .8em;
   opacity: 70%;
 	margin-right: 10px;
+	color: #777;
 }
 
 #pets-index {
@@ -189,6 +190,22 @@ main {
 .pet-card .options {
   margin: 5px 15px 15px 5px;
   text-align: right;
+}
+
+.pet-card .options a {
+  font-size: .8em;
+  opacity: 70%;
+	margin-right: 10px;
+}
+
+.options a {
+  font-size: .8em;
+  opacity: 70%;
+	/* margin-right: 10px; */
+}
+
+.options a:hover {
+  color: #9900CC;
 }
 
 .edit-form {
@@ -240,7 +257,7 @@ main {
 }
 
 .pet-image {
-  width: 100%;
+  width: 50%;
   height: 100%;
   object-fit: cover;
   object-position: 50% 50%;
@@ -253,7 +270,7 @@ main {
 }
 
 #pet-detail .options {
-  margin: 20px 0 100px 0;
+  margin: 20px 0 30px 0;
 }
 
 #pet-detail .options a {
@@ -282,22 +299,34 @@ main {
 	margin-top: 20px;
 }
 
-#pet-apps {
+#list-section {
 	margin: 40px 0 30px 0;
 	padding-top: 10px;
 	border-top: 1px solid #ddd;
 }
 
-#pet-apps .app {
+#list-section .list {
 	margin-left: 30px;
 }
 
-#pet-apps .app {
+#list-section .list {
 	margin-bottom: 10px;
 }
 
-#pet-apps .app .app-name:hover {
+#list-section .list .list-name:hover {
 	color: #9900CC;
+}
+
+.pet-list {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  margin: 0px 0 20px 0px;
+	align-content: baseline;
+}
+
+.pet-list .options {
+	margin-top: 0px;
 }
 
 #flash-alert {

--- a/app/assets/stylesheets/main.css
+++ b/app/assets/stylesheets/main.css
@@ -329,6 +329,15 @@ main {
 	margin-top: 0px;
 }
 
+#app-detail {
+	line-height: 22px;
+}
+
+#app-detail small {
+	font-size: .8em;
+	color: #777;
+}
+
 #flash-alert {
 	background-color: red;
 }

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -1,4 +1,8 @@
 class ApplicationsController < ApplicationController
+  def index
+    @applicants = Application.find(ApplicationPet.where(pet_id: params[:pet_id]).pluck(:application_id))
+    @pet = Pet.find(params[:pet_id])
+  end
 
   def new
     @fav_pet_objects = favorite.pet_objects

--- a/app/views/applications/index.html.erb
+++ b/app/views/applications/index.html.erb
@@ -1,0 +1,16 @@
+<main>
+  <section class='page-header'>
+    <h2 class='page-title'>Applicants for: <%= "#{@pet.name}" %></h2>
+  </section>
+  <section id='app-index'>
+    <% if @applicants.any? %>
+      <% @applicants.each do |applicant| %>
+        <div class='app-names'>
+          <h4><%= link_to "#{applicant.name}", "/applications/#{applicant.id}", class: 'list-name' %></h4>
+        </div>
+      <% end %>
+    <% else %>
+      <p>There are no current applications for this pet.</p>
+    <% end %>
+  </section>
+</main>

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -1,6 +1,6 @@
 <main>
   <section class='page-header'>
-    <h2 class='page-title'>Application for <%= @application.name %></h2>
+    <h2 class='page-title'>Application for: <%= @application.name %></h2>
   </section>
 
   <div>
@@ -8,14 +8,20 @@
     <p>City: <%= @application.city %></p>
     <p>State: <%= @application.state %></p>
     <p>Zip Code: <%= @application.zip %></p>
-    <p>Phone Number: <%= @application.phone_number %></p>
+    <p>Phone Number: <%= @application.phone_number %></p><br>
     <p>Adoption Reason: <%= @application.reason %></p><br>
-    <ul>
-      <h4>Current Pets Requested</h4>
-        <% @pets.each do |pet| %>
-          <li><%= link_to "#{pet.name}", "/pets/#{pet.id}" %></li>
-          <dd>- <%= link_to "Click here to approve application for #{pet.name}", "/pets/#{pet.id}", action: "#{pet}.update(status: 'pending')" %></dd>
-      <% end %>
-    </ul>
   </div>
+  <section id='list-section'>
+    <div class='page-header'>
+      <h3 class='page-title'>Current Pets Requested</h3>
+    </div>
+      <% @pets.each do |pet| %>
+        <div class='pet-list'>
+          <h4><%= link_to "#{pet.name}", "/pets/#{pet.id}" %></h4>
+          <span class='options'>
+            <%= link_to "Approve", "/pets/#{pet.id}", action: "#{pet}.update(status: 'pending')" %>
+          </span>
+        </div>
+      <% end %>
+  </section>
 </main>

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -3,13 +3,15 @@
     <h2 class='page-title'>Application for: <%= @application.name %></h2>
   </section>
 
-  <div>
-    <p>Address: <%= @application.address %></p>
-    <p>City: <%= @application.city %></p>
-    <p>State: <%= @application.state %></p>
-    <p>Zip Code: <%= @application.zip %></p>
-    <p>Phone Number: <%= @application.phone_number %></p><br>
-    <p>Adoption Reason: <%= @application.reason %></p><br>
+  <div id='app-detail'>
+    <p><%= @application.address %></p>
+    <p><%= @application.city %>, <%= @application.state %></p>
+    <p><%= @application.zip %></p><br>
+    <small>Phone Number:</small>
+    <p><%= @application.phone_number %></p><br>
+
+    <small>Adoption Reason:</small>
+    <p><%= @application.reason %></p>
   </div>
   <section id='list-section'>
     <div class='page-header'>

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -21,7 +21,7 @@
         <div class='pet-list'>
           <h4><%= link_to "#{pet.name}", "/pets/#{pet.id}" %></h4>
           <span class='options'>
-            <%= link_to "Approve", "/pets/#{pet.id}", action: "#{pet}.update(status: 'pending')" %>
+            <%= link_to 'Approve', "/pets/#{pet.id}?status=pending", method: :patch %>
           </span>
         </div>
       <% end %>

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -21,7 +21,11 @@
         <div class='pet-list'>
           <h4><%= link_to "#{pet.name}", "/pets/#{pet.id}" %></h4>
           <span class='options'>
-            <%= link_to 'Approve', "/pets/#{pet.id}?status=pending", method: :patch %>
+            <% if pet.status == 'pending' %>
+              <%= link_to 'Unapprove', "/pets/#{pet.id}?status=adoptable", method: :patch %>
+            <% else %>
+              <%= link_to 'Approve', "/pets/#{pet.id}?status=pending", method: :patch %>
+            <% end %>
           </span>
         </div>
       <% end %>

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -38,16 +38,19 @@
       <p>You have no favorite pets.</p><br><br>
     <% end %>
   </section>
-  <section>
-    <div>
-      <% if @pets.any? %>
-        <h3>Pets with current applications:</h3><br>
-        <% @pets.each do |pet| %>
-          <ul>
-            <li><%= link_to "#{pet.name}", "/pets/#{pet.id}" %><br>
-          </ul>
-      <% end  %>
+
+  <section id='pet-apps'>
+
+    <div class='page-header'>
+      <h3 class='page-title'>Pets with Applications</h3>
     </div>
+
+    <% if @pets.any? %>
+      <% @pets.each do |pet| %>
+          <ul class='app'>
+            <li><%= link_to "#{pet.name}", "/pets/#{pet.id}", class: 'app-name' %></li>
+          </ul>
+      <% end %>
     <% end %>
   </section>
 </main>

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -39,7 +39,7 @@
     <% end %>
   </section>
 
-  <section id='pet-apps'>
+  <section id='list-section'>
 
     <div class='page-header'>
       <h3 class='page-title'>Pets with Applications</h3>
@@ -47,8 +47,8 @@
 
     <% if @pets.any? %>
       <% @pets.each do |pet| %>
-          <ul class='app'>
-            <li><%= link_to "#{pet.name}", "/pets/#{pet.id}", class: 'app-name' %></li>
+          <ul class='list'>
+            <li><%= link_to "#{pet.name}", "/pets/#{pet.id}", class: 'list-name' %></li>
           </ul>
       <% end %>
     <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,4 +18,7 @@
   <body>
     <%= yield %>
   </body>
+  <footer>
+    <small>2020 - Mod 2 Paired Project - Adopt Dont Shop<br>Nick Edwin & Gaby Mendez</small>
+  </footer>
 </html>

--- a/app/views/pets/show.html.erb
+++ b/app/views/pets/show.html.erb
@@ -30,6 +30,7 @@
       <% else %>
         <%= link_to 'Add pet to favorites', "/favorites/#{@pet.id}", method: :post %>
       <% end %>
+      <%= link_to 'See Applicants', "/applications?pet_id=#{@pet.id}" %>
     </div>
   </section>
 

--- a/app/views/pets/show.html.erb
+++ b/app/views/pets/show.html.erb
@@ -9,10 +9,10 @@
     <% end %>
   </div>
 
-  <div>
+  <div id='on-hold'>
     <% if @pet.status == "pending" %>
       <p>This pet is currently on hold for: <%= @applicants.map {|applicant| applicant.name}.pop %></p>
-    <%  end %>
+    <% end %>
   </div>
 
   <section id='pet-detail'>

--- a/app/views/pets/show.html.erb
+++ b/app/views/pets/show.html.erb
@@ -34,18 +34,4 @@
     </div>
   </section>
 
-  <section id='list-section'>
-    <div class='page-header'>
-      <h3 class='page-title'>Applicants for this Pet</h3>
-    </div>
-    <% if @applicants.any? %>
-      <% @applicants.each do |applicant| %>
-        <ul class='list'>
-          <li><%= link_to "#{applicant.name}", "/applications/#{applicant.id}", class: 'list-name' %></li>
-        </ul>
-      <% end %>
-    <% else %>
-      <p>There are no current applications for this pet.</p>
-    <% end %>
-  </section>
 </main>

--- a/app/views/pets/show.html.erb
+++ b/app/views/pets/show.html.erb
@@ -19,7 +19,6 @@
 
     <%= image_tag(@pet.image, alt: "photo of pet", method: :get, class: 'pet-image') %>
 
-
     <p><%= @pet.approx_age %> year(s), <%= @pet.sex %><br>
     <%= @pet.description %></p>
 
@@ -33,10 +32,16 @@
       <% end %>
     </div>
   </section>
-  <section>
+
+  <section id='list-section'>
+    <div class='page-header'>
+      <h3 class='page-title'>Applicants for this Pet</h3>
+    </div>
     <% if @applicants.any? %>
       <% @applicants.each do |applicant| %>
-        <p>Applicants for this pet: <%= link_to "#{applicant.name}", "/applications/#{applicant.id}" %></p><br>
+        <ul class='list'>
+          <li><%= link_to "#{applicant.name}", "/applications/#{applicant.id}", class: 'list-name' %></li>
+        </ul>
       <% end %>
     <% else %>
       <p>There are no current applications for this pet.</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,5 +34,7 @@ Rails.application.routes.draw do
   get '/applications/new', to: 'applications#new'
   post '/applications', to: 'applications#create'
   get '/applications/:id', to: 'applications#show'
+  get '/applications', to: 'applications#index'
+  get '/applications?pet_id', to: 'applications#index'
 
 end

--- a/spec/features/applications/index_spec.rb
+++ b/spec/features/applications/index_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe 'as a visitor' do
+  before :each do
+    @shelter = Shelter.create(name: "Braun Farm")
+    @pet1 = Pet.create(name: 'Noodle', approx_age: 3, sex: "male", description: "description of noodle", image: "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/13001403/Australian-Cattle-Dog-On-White-03.jpg", shelter_id: @shelter.id, status: "adoptable" )
+    @pet2 = Pet.create(name: 'Yoda', approx_age: 3, sex: "male", description: "description of noodle", image: "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/13001403/Australian-Cattle-Dog-On-White-03.jpg", shelter_id: @shelter.id, status: "adoptable" )
+    @application1 = Application.create(name: 'Timmy', address: '123 Street St.', city: 'Denver', state: 'CO', zip: '80218', phone_number: '303-123-4567', reason: 'Because I love animals!')
+    ApplicationPet.create(application_id: @application1.id, pet_id: @pet1.id)
+  end
+
+  it 'Displays outstanding applications for a pet' do
+    visit "/pets/#{@pet1.id}"
+
+    click_on "See Applicants"
+
+    expect(current_path).to eq("/applications")
+
+    click_on "Timmy"
+
+    expect(current_path).to eq("/applications/#{@application1.id}")
+  end
+
+  it 'Displays that a pet has no applicants' do
+    visit "/pets/#{@pet2.id}"
+
+    click_on "See Applicants"
+
+    expect(current_path).to eq("/applications")
+
+    expect(page).to have_content("There are no current applications for this pet.")
+  end
+end 

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "as a visitor", type: :feature do
       expect(page).to have_content('CO')
       expect(page).to have_content('80218')
       expect(page).to have_content('303-123-4567')
-      expect(page).to have_content('Adoption Reason: Because I love animals!')
+      expect(page).to have_content('Because I love animals!')
 
       expect(page).to have_selector(:link_or_button, 'Noodle')
       click_on 'Noodle'

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -12,11 +12,11 @@ RSpec.describe "as a visitor", type: :feature do
       visit "/applications/#{@application1.id}"
 
       expect(page).to have_content('Timmy')
-      expect(page).to have_content('Address: 123 Street St.')
-      expect(page).to have_content('City: Denver')
-      expect(page).to have_content('State: CO')
-      expect(page).to have_content('Zip Code: 80218')
-      expect(page).to have_content('Phone Number: 303-123-4567')
+      expect(page).to have_content('123 Street St.')
+      expect(page).to have_content('Denver')
+      expect(page).to have_content('CO')
+      expect(page).to have_content('80218')
+      expect(page).to have_content('303-123-4567')
       expect(page).to have_content('Adoption Reason: Because I love animals!')
 
       expect(page).to have_selector(:link_or_button, 'Noodle')

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -29,9 +29,9 @@ RSpec.describe "as a visitor", type: :feature do
 
       visit "/applications/#{@application1.id}"
 
-      expect(page).to have_selector(:link_or_button, 'Click here to approve application for Noodle')
+      expect(page).to have_selector(:link_or_button, 'Approve')
 
-      click_on 'Click here to approve application for Noodle'
+      click_on 'Approve'
 
       expect(current_path).to eq("/pets/#{@pet1.id}")
     end

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -1,12 +1,12 @@
 RSpec.describe "as a visitor", type: :feature do
-  before :each do
-    @shelter = Shelter.create(name: "Braun Farm")
-    @pet1 = Pet.create(name: 'Noodle', approx_age: 3, sex: "male", description: "description of noodle", image: "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/13001403/Australian-Cattle-Dog-On-White-03.jpg", shelter_id: @shelter.id, status: "adoptable" )
-    @application1 = Application.create(name: 'Timmy', address: '123 Street St.', city: 'Denver', state: 'CO', zip: '80218', phone_number: '303-123-4567', reason: 'Because I love animals!')
-    ApplicationPet.create(application_id: @application1.id, pet_id: @pet1.id)
-  end
-
   describe 'view applications show' do
+    before :each do
+      @shelter = Shelter.create(name: "Braun Farm")
+      @pet1 = Pet.create(name: 'Noodle', approx_age: 3, sex: "male", description: "description of noodle", image: "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/13001403/Australian-Cattle-Dog-On-White-03.jpg", shelter_id: @shelter.id, status: "adoptable" )
+      @application1 = Application.create(name: 'Timmy', address: '123 Street St.', city: 'Denver', state: 'CO', zip: '80218', phone_number: '303-123-4567', reason: 'Because I love animals!')
+      ApplicationPet.create(application_id: @application1.id, pet_id: @pet1.id)
+    end
+
     it 'can see applicants and the pets they applied for' do
 
       visit "/applications/#{@application1.id}"

--- a/spec/features/pets/show_spec.rb
+++ b/spec/features/pets/show_spec.rb
@@ -46,36 +46,4 @@ RSpec.describe 'as a visitor' do
     expect(page).to have_selector(:link_or_button, 'Remove pet from favorites')
   end
 
-  it 'Displays outstanding applications for a pet' do
-    visit "/pets/#{@pet1.id}"
-
-    click_on "See Applicants"
-
-    expect(current_path).to eq("/applications")
-
-    click_on "Timmy"
-
-    expect(current_path).to eq("/applications/#{@application1.id}")
-  end
-
-  it 'Displays that a pet has no applicants' do
-    visit "/pets/#{@pet2.id}"
-
-    click_on "See Applicants"
-
-    expect(current_path).to eq("/applications")
-
-    expect(page).to have_content("There are no current applications for this pet.")
-  end
-
-  it "Updates show page for pending application" do
-    visit "/applications/#{@application1.id}"
-
-    click_on "Approve"
-
-    expect(current_path).to eq("/pets/#{@pet1.id}")
-
-    expect(page).to have_content("This pet is currently on hold for: Timmy")
-    expect(page).to have_content('status: pending')
-  end
 end

--- a/spec/features/pets/show_spec.rb
+++ b/spec/features/pets/show_spec.rb
@@ -67,11 +67,11 @@ RSpec.describe 'as a visitor' do
   it "Updates show page for pending application" do
     visit "/applications/#{@application1.id}"
 
-    click_on "Click here to approve application for #{@pet1.name}"
+    click_on "Approve"
 
     expect(current_path).to eq("/pets/#{@pet1.id}")
 
-    expect(page).to have_content("This pet is currently on hold for: #{@application1.name}")
+    expect(page).to have_content("This pet is currently on hold for: Timmy")
     expect(page).to have_content('status: pending')
   end
 end

--- a/spec/features/pets/show_spec.rb
+++ b/spec/features/pets/show_spec.rb
@@ -46,4 +46,14 @@ RSpec.describe 'as a visitor' do
     expect(page).to have_selector(:link_or_button, 'Remove pet from favorites')
   end
 
+  it 'Shows status: pending once an application has been approved' do
+
+    visit "/applications/#{@application1.id}"
+    click_on 'Approve'
+    expect(current_path).to eq("/pets/#{@pet1.id}")
+
+    expect(page).to have_content('status: pending')
+    expect(page).to have_content('This pet is currently on hold for: Timmy')
+  end
+
 end

--- a/spec/features/pets/show_spec.rb
+++ b/spec/features/pets/show_spec.rb
@@ -49,7 +49,9 @@ RSpec.describe 'as a visitor' do
   it 'Displays outstanding applications for a pet' do
     visit "/pets/#{@pet1.id}"
 
-    expect(page).to have_selector(:link_or_button, "Timmy")
+    click_on "See Applicants"
+
+    expect(current_path).to eq("/applications")
 
     click_on "Timmy"
 
@@ -58,6 +60,10 @@ RSpec.describe 'as a visitor' do
 
   it 'Displays that a pet has no applicants' do
     visit "/pets/#{@pet2.id}"
+
+    click_on "See Applicants"
+
+    expect(current_path).to eq("/applications")
 
     expect(page).to have_content("There are no current applications for this pet.")
   end

--- a/spec/features/pets/show_spec.rb
+++ b/spec/features/pets/show_spec.rb
@@ -49,8 +49,6 @@ RSpec.describe 'as a visitor' do
   it 'Displays outstanding applications for a pet' do
     visit "/pets/#{@pet1.id}"
 
-    expect(page).to have_content("Applicants for this pet: Timmy")
-
     expect(page).to have_selector(:link_or_button, "Timmy")
 
     click_on "Timmy"


### PR DESCRIPTION
@NickEdwin 

- User story #20 is actually asking for a separate `applications#index` (instead of showing the applications on the pets#show page) so I created that and associated routes. The `pet.id` gets ported over to `applications#index` via a query param: `/applications?pet_id=#{pet.id}` 

- When you click 'Approve', the `status=pending` gets ported over with a query param as well that routes to `pets#update`  (the way you had that `link_to` written out didn't seem to work for me before, so I changed to this...?)

- User story #25 is done (approve/disapprove link toggle). The way this currently works is using an if/else in the applications#show page view. HOWEVER, this needs a bit more work in order to complete User Story #24, because there has to be a third option on that link, such as 'waiting list' or no option at all in the event that there is an approved application on the pet that is not the application in question. The way I imagine this will work is by maybe adding a `status` column to the `Applications` table that will keep track that fact. Then, we can modify the conditional on the `applications#show` link view to reflect this.

TLDR; stories 22, 23, and 25 got done as well as styling for all the new pieces. 
All tests pass except for the one that involves a checkbox... still.