### PR TITLE
Pending (remove status from pets, add to ApplicationPets)

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ I'm able to approve the application for any number of pets
 ```
 User Story 24, Pets can only have one approved application on them at any time
 
-[ ] done
+[X] done
 
 As a visitor
 When a pet has more than one application made for them

--- a/app/controllers/application_pets_controller.rb
+++ b/app/controllers/application_pets_controller.rb
@@ -1,6 +1,0 @@
-class ApplicationPetsController < ApplicationController
-  def update
-    pet = Pet.find(params[:pet_id])
-    approve_for(pet)
-  end
-end

--- a/app/controllers/application_pets_controller.rb
+++ b/app/controllers/application_pets_controller.rb
@@ -1,0 +1,6 @@
+class ApplicationPetsController < ApplicationController
+  def update
+    pet = Pet.find(params[:pet_id])
+    approve_for(pet)
+  end
+end

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -30,6 +30,13 @@ class ApplicationsController < ApplicationController
     @application = Application.find(params[:id])
   end
 
+  def update
+    application = Application.find(params[:id])
+    pet = Pet.find(params[:pet_id])
+    application.approve_for(pet)
+    redirect_to "/applications/#{params[:id]}"
+  end
+
   private
   def application_params
     params.permit(:name, :address, :city, :state, :zip, :phone_number, :reason)

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -28,7 +28,6 @@ class ApplicationsController < ApplicationController
 
   def show
     @application = Application.find(params[:id])
-    @pets = Pet.find(ApplicationPet.where(application_id: @application.id).pluck(:pet_id))
   end
 
   private

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -33,8 +33,13 @@ class ApplicationsController < ApplicationController
   def update
     application = Application.find(params[:id])
     pet = Pet.find(params[:pet_id])
-    application.approve_for(pet)
-    redirect_to "/applications/#{params[:id]}"
+    if application.can_approve(pet)
+      application.approve_for(pet)
+      redirect_to "/pets/#{pet.id}"
+    elsif application.can_unapprove(pet)
+      application.unapprove_for(pet)
+      redirect_to "/applications/#{application.id}"
+    end
   end
 
   private

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -11,7 +11,7 @@ class ApplicationsController < ApplicationController
   def create
     application = Application.new(application_params)
 
-    pet_ids = params[:applications][:pet_ids]
+    pet_ids = params[:application][:pet_ids]
 
     if application.save
       pet_ids.each do |id|

--- a/app/controllers/pets_controller.rb
+++ b/app/controllers/pets_controller.rb
@@ -47,7 +47,7 @@ class PetsController < ApplicationController
 
   private
   def pet_params
-    params.permit(:name, :approx_age, :description, :sex, :image, :status)
+    params.permit(:name, :approx_age, :description, :sex, :image)
   end
 
 end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -29,4 +29,10 @@ class Application < ApplicationRecord
       end
     end
   end
+
+  def can_unapprove(pet)
+    find_app_pet(pet).any? do |ap|
+      ap.approve == true
+    end
+  end
 end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -10,4 +10,23 @@ class Application < ApplicationRecord
   has_many :application_pets
   has_many :pets, through: :application_pets
 
+  def find_app_pet(pet)
+    self.application_pets.where(pet_id: pet.id)
+  end
+
+  def can_approve(pet)
+    if pet.application_pets.where(approve: true) != []
+      false
+    else
+      true
+    end
+  end
+
+  def approve_for(pet)
+    if can_approve(pet)
+      find_app_pet(pet).map do |ap|
+        ap.toggle_status
+      end
+    end
+  end
 end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -22,6 +22,12 @@ class Application < ApplicationRecord
     end
   end
 
+  def can_unapprove(pet)
+    find_app_pet(pet).any? do |ap|
+      ap.approve == true
+    end
+  end
+
   def approve_for(pet)
     if can_approve(pet)
       find_app_pet(pet).map do |ap|
@@ -30,9 +36,11 @@ class Application < ApplicationRecord
     end
   end
 
-  def can_unapprove(pet)
-    find_app_pet(pet).any? do |ap|
-      ap.approve == true
-    end
+  def unapprove_for(pet)
+    find_app_pet(pet).map do |ap|
+      ap.toggle_status
+    end 
   end
+
+
 end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -9,4 +9,5 @@ class Application < ApplicationRecord
 
   has_many :application_pets
   has_many :pets, through: :application_pets
+
 end

--- a/app/models/application_pet.rb
+++ b/app/models/application_pet.rb
@@ -10,12 +10,12 @@ class ApplicationPet < ApplicationRecord
     self.update(approve: false)
   end
 
-  def toggle
+  def toggle_status
     if self.approve
       self.unapprove
     else
       self.approve_app
-    end 
+    end
   end
 
 end

--- a/app/models/application_pet.rb
+++ b/app/models/application_pet.rb
@@ -6,4 +6,16 @@ class ApplicationPet < ApplicationRecord
     self.update(approve: true)
   end
 
+  def unapprove
+    self.update(approve: false)
+  end
+
+  def toggle
+    if self.approve
+      self.unapprove
+    else
+      self.approve_app
+    end 
+  end
+
 end

--- a/app/models/application_pet.rb
+++ b/app/models/application_pet.rb
@@ -1,4 +1,9 @@
 class ApplicationPet < ApplicationRecord
   belongs_to :application
   belongs_to :pet
+
+  def approve_app
+    self.update(approve: true)
+  end
+
 end

--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -8,4 +8,13 @@ class Pet < ApplicationRecord
 
   has_many :application_pets
   has_many :applications, through: :application_pets
+
+  # def status
+  #   approved_apps = self.application_pets.where(status: "approved")
+  #   if approved_apps.any?
+  #     :pending
+  #   else
+  #     :adoptable
+  #   end
+  # end
 end

--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -9,12 +9,12 @@ class Pet < ApplicationRecord
   has_many :application_pets
   has_many :applications, through: :application_pets
 
-  # def status
-  #   approved_apps = self.application_pets.where(status: "approved")
-  #   if approved_apps.any?
-  #     :pending
-  #   else
-  #     :adoptable
-  #   end
-  # end
+  def status
+    approved_apps = self.application_pets.where(approve: true)
+    if approved_apps.any?
+      :pending
+    else
+      :adoptable
+    end
+  end
 end

--- a/app/views/applications/new.html.erb
+++ b/app/views/applications/new.html.erb
@@ -17,7 +17,7 @@
       <p>Select which pet/pets you'd like to apply for:</p><br>
 
       <div class='checkbox'>
-        <%= collection_check_boxes(:applications, :pet_ids, @fav_pet_objects, :id, :name, {include_hidden: false}) %>
+        <%= collection_check_boxes(:application, :pet_ids, @fav_pet_objects, :id, :name, {include_hidden: false}) %>
       </div>
 
       <br><br>

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -17,7 +17,7 @@
     <div class='page-header'>
       <h3 class='page-title'>Current Pets Requested</h3>
     </div>
-      <% @pets.each do |pet| %>
+      <% @application.pets.each do |pet| %>
         <div class='pet-list'>
           <h4><%= link_to "#{pet.name}", "/pets/#{pet.id}" %></h4>
           <span class='options'>

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -21,10 +21,12 @@
         <div class='pet-list'>
           <h4><%= link_to "#{pet.name}", "/pets/#{pet.id}" %></h4>
           <span class='options'>
-            <% if pet.status == 'pending' %>
-              <%= link_to 'Unapprove', "/pets/#{pet.id}?status=adoptable", method: :patch %>
+            <% if @application.can_approve(pet) %>
+              <%= link_to 'Approve', "/applications/#{@application.id}?pet_id=#{pet.id}", method: :patch %>
+            <% elsif @application.can_unapprove(pet) %>
+              <%= link_to 'Unapprove', "/applications/#{@application.id}?pet_id=#{pet.id}", method: :patch %>
             <% else %>
-              <%= link_to 'Approve', "/pets/#{pet.id}?status=pending", method: :patch %>
+              <span>An application is already pending.</span>
             <% end %>
           </span>
         </div>

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -22,9 +22,9 @@
           <h4><%= link_to "#{pet.name}", "/pets/#{pet.id}" %></h4>
           <span class='options'>
             <% if @application.can_approve(pet) %>
-              <%= link_to 'Approve', "/applications/#{@application.id}?pet_id=#{pet.id}", method: :patch %>
+              <%= link_to 'Approve', "/applications/#{@application.id}?pet_id=#{pet.id}&approve=true", method: :patch %>
             <% elsif @application.can_unapprove(pet) %>
-              <%= link_to 'Unapprove', "/applications/#{@application.id}?pet_id=#{pet.id}", method: :patch %>
+              <%= link_to 'Unapprove', "/applications/#{@application.id}?pet_id=#{pet.id}&approve=false", method: :patch %>
             <% else %>
               <span>An application is already pending.</span>
             <% end %>

--- a/app/views/pets/show.html.erb
+++ b/app/views/pets/show.html.erb
@@ -11,7 +11,10 @@
 
   <div id='on-hold'>
     <% if @pet.status == :pending %>
-      <p>This pet is currently on hold for: <%= @applicants.map {|applicant| applicant.name}.pop %></p>
+      <% app = @pet.applications.select do |application| %>
+        <% application.find_app_pet(@pet)[0].approve == true %>
+      <% end %>
+      <p>This pet is currently on hold for: <%= app[0].name %> </p>
     <% end %>
   </div>
 

--- a/app/views/pets/show.html.erb
+++ b/app/views/pets/show.html.erb
@@ -10,7 +10,7 @@
   </div>
 
   <div id='on-hold'>
-    <% if @pet.status == "pending" %>
+    <% if @pet.status == :pending %>
       <p>This pet is currently on hold for: <%= @applicants.map {|applicant| applicant.name}.pop %></p>
     <% end %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,4 +37,7 @@ Rails.application.routes.draw do
   get '/applications', to: 'applications#index'
   get '/applications?pet_id', to: 'applications#index'
 
+  patch '/applications/:id', to: 'applications#update'
+
+
 end

--- a/db/migrate/20200713234527_add_approve_to_application_pets.rb
+++ b/db/migrate/20200713234527_add_approve_to_application_pets.rb
@@ -1,0 +1,5 @@
+class AddApproveToApplicationPets < ActiveRecord::Migration[5.1]
+  def change
+    add_column :application_pets, :approve, :boolean, default: false
+  end
+end

--- a/db/migrate/20200714001833_remove_status_from_applications.rb
+++ b/db/migrate/20200714001833_remove_status_from_applications.rb
@@ -1,0 +1,5 @@
+class RemoveStatusFromApplications < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :applications, :status
+  end
+end

--- a/db/migrate/20200714012435_remove_status_from_pets.rb
+++ b/db/migrate/20200714012435_remove_status_from_pets.rb
@@ -1,0 +1,5 @@
+class RemoveStatusFromPets < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :pets, :status, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200711213704) do
+ActiveRecord::Schema.define(version: 20200714001833) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 20200711213704) do
     t.bigint "pet_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "approve", default: false
     t.index ["application_id"], name: "index_application_pets_on_application_id"
     t.index ["pet_id"], name: "index_application_pets_on_pet_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200714001833) do
+ActiveRecord::Schema.define(version: 20200714012435) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -45,7 +45,6 @@ ActiveRecord::Schema.define(version: 20200714001833) do
     t.string "image"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "status"
     t.text "description"
     t.index ["shelter_id"], name: "index_pets_on_shelter_id"
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,8 +9,8 @@
 shelter = Shelter.create(name: "Braun Farm", address: '4242 Farm Rd.', city: 'Eustis', state: 'FL', zip: 33790)
 shelter2 = Shelter.create(name: "Jax Rescue", address: '30 Matanzas Way.', city: 'Jacksonville', state: 'FL', zip: 33578)
 
-pet1 = Pet.create(name: 'Noodle', approx_age: 3, sex: "male", image: "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/13001403/Australian-Cattle-Dog-On-White-03.jpg", shelter_id: shelter.id, status: 'adoptable' )
+pet1 = Pet.create(name: 'Noodle', approx_age: 3, sex: "male", image: "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/13001403/Australian-Cattle-Dog-On-White-03.jpg", shelter_id: shelter.id)
 
-pet2 = Pet.create(name: 'Marley', approx_age: 12, sex: "female", image: "https://s3-eu-west-1.amazonaws.com/w3.cdn.gpd/gb.pedigree.56/large_e6bfdad9-6951-407b-a11f-bbd0c25bd796.jpg", shelter_id: shelter.id, status: 'adoptable' )
+pet2 = Pet.create(name: 'Marley', approx_age: 12, sex: "female", image: "https://s3-eu-west-1.amazonaws.com/w3.cdn.gpd/gb.pedigree.56/large_e6bfdad9-6951-407b-a11f-bbd0c25bd796.jpg", shelter_id: shelter.id)
 
-pet3 = Pet.create(name: 'Leo', approx_age: 7, sex: 'male', image: "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/12235957/Border-Collie-On-White-01.jpg", shelter_id: shelter2.id, status: 'adoptable')
+pet3 = Pet.create(name: 'Leo', approx_age: 7, sex: 'male', image: "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/12235957/Border-Collie-On-White-01.jpg", shelter_id: shelter2.id)

--- a/spec/features/applications/index_spec.rb
+++ b/spec/features/applications/index_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe 'as a visitor' do
   before :each do
     @shelter = Shelter.create(name: "Braun Farm")
-    @pet1 = Pet.create(name: 'Noodle', approx_age: 3, sex: "male", description: "description of noodle", image: "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/13001403/Australian-Cattle-Dog-On-White-03.jpg", shelter_id: @shelter.id, status: "adoptable" )
-    @pet2 = Pet.create(name: 'Yoda', approx_age: 3, sex: "male", description: "description of noodle", image: "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/13001403/Australian-Cattle-Dog-On-White-03.jpg", shelter_id: @shelter.id, status: "adoptable" )
+    @pet1 = Pet.create(name: 'Noodle', approx_age: 3, sex: "male", description: "description of noodle", image: "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/13001403/Australian-Cattle-Dog-On-White-03.jpg", shelter_id: @shelter.id)
+    @pet2 = Pet.create(name: 'Yoda', approx_age: 3, sex: "male", description: "description of noodle", image: "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/13001403/Australian-Cattle-Dog-On-White-03.jpg", shelter_id: @shelter.id)
     @application1 = Application.create(name: 'Timmy', address: '123 Street St.', city: 'Denver', state: 'CO', zip: '80218', phone_number: '303-123-4567', reason: 'Because I love animals!')
     ApplicationPet.create(application_id: @application1.id, pet_id: @pet1.id)
   end
@@ -28,4 +28,4 @@ RSpec.describe 'as a visitor' do
 
     expect(page).to have_content("There are no current applications for this pet.")
   end
-end 
+end

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe "as a visitor", type: :feature do
   describe 'view applications show' do
     before :each do
       @shelter = Shelter.create(name: "Braun Farm")
-      @pet1 = Pet.create(name: 'Noodle', approx_age: 3, sex: "male", description: "description of noodle", image: "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/13001403/Australian-Cattle-Dog-On-White-03.jpg", shelter_id: @shelter.id, status: "adoptable" )
+      @pet1 = Pet.create(name: 'Noodle', approx_age: 3, sex: "male", description: "description of noodle", image: "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/13001403/Australian-Cattle-Dog-On-White-03.jpg", shelter_id: @shelter.id)
       @application1 = Application.create(name: 'Timmy', address: '123 Street St.', city: 'Denver', state: 'CO', zip: '80218', phone_number: '303-123-4567', reason: 'Because I love animals!')
       ApplicationPet.create(application_id: @application1.id, pet_id: @pet1.id)
     end

--- a/spec/features/favorites/index_spec.rb
+++ b/spec/features/favorites/index_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe "as a visitor", type: :feature do
   before :each do
     @shelter = Shelter.create(name: "Braun Farm")
-    @pet1 = Pet.create(name: 'Noodle', approx_age: 3, sex: "male", description: "description of noodle", image: "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/13001403/Australian-Cattle-Dog-On-White-03.jpg", shelter_id: @shelter.id, status: "adoptable" )
-    @pet2 = Pet.create(name: 'Yoda', approx_age: 4, sex: "female", description: "This is a cat.", image: "https://static.toiimg.com/photo/msid-67586673/67586673.jpg?3918697", shelter_id: @shelter.id, status: "adoptable" )
+    @pet1 = Pet.create(name: 'Noodle', approx_age: 3, sex: "male", description: "description of noodle", image: "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/13001403/Australian-Cattle-Dog-On-White-03.jpg", shelter_id: @shelter.id)
+    @pet2 = Pet.create(name: 'Yoda', approx_age: 4, sex: "female", description: "This is a cat.", image: "https://static.toiimg.com/photo/msid-67586673/67586673.jpg?3918697", shelter_id: @shelter.id)
 
   end
 

--- a/spec/features/nav_spec.rb
+++ b/spec/features/nav_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe 'as a visitor' do
     it 'then I see links at the top for pet index and shelter index' do
 
       shelter = Shelter.create!(name: "Braun Farm")
-      pet = Pet.create!(name: 'Noodle', approx_age: 3, sex: "male", image: "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/13001403/Australian-Cattle-Dog-On-White-03.jpg", shelter_id: shelter.id, status: 'adoptable' )
+      pet = Pet.create!(name: 'Noodle', approx_age: 3, sex: "male", image: "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/13001403/Australian-Cattle-Dog-On-White-03.jpg", shelter_id: shelter.id)
 
       visit "/shelters"
       expect(page).to have_link('Pets')

--- a/spec/features/pet_links_spec.rb
+++ b/spec/features/pet_links_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'as a visitor' do
 
       shelter = Shelter.create(name: "Braun Farm")
 
-      pet1 = Pet.create!(name: 'Noodle', approx_age: 3, sex: "male", description: "description of noodle", image: "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/13001403/Australian-Cattle-Dog-On-White-03.jpg", shelter_id: shelter.id, status: "adoptable" )
+      pet1 = Pet.create!(name: 'Noodle', approx_age: 3, sex: "male", description: "description of noodle", image: "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/13001403/Australian-Cattle-Dog-On-White-03.jpg", shelter_id: shelter.id)
 
 
       visit '/pets'

--- a/spec/features/pets/delete_spec.rb
+++ b/spec/features/pets/delete_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "as a visitor", type: :feature do
 
       shelter = Shelter.create(name: "Braun Farm")
 
-      pet1 = Pet.create!(name: 'Noodle', approx_age: 3, sex: "male", description: "description of noodle", image: "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/13001403/Australian-Cattle-Dog-On-White-03.jpg", shelter_id: shelter.id, status: "adoptable" )
+      pet1 = Pet.create!(name: 'Noodle', approx_age: 3, sex: "male", description: "description of noodle", image: "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/13001403/Australian-Cattle-Dog-On-White-03.jpg", shelter_id: shelter.id )
 
       visit "/pets/#{pet1.id}"
       click_on "Delete"

--- a/spec/features/pets/edit_spec.rb
+++ b/spec/features/pets/edit_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe "as a visitor", type: :feature do
 
     shelter = Shelter.create!(name: "Braun Farm")
 
-    pet1 = Pet.create!(name: 'Noodle', approx_age: 3, sex: "male", description: "description of noodle", image: "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/13001403/Australian-Cattle-Dog-On-White-03.jpg", shelter_id: shelter.id, status: "adoptable" )
+    pet1 = Pet.create!(name: 'Noodle', approx_age: 3, sex: "male", description: "description of noodle", image: "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/13001403/Australian-Cattle-Dog-On-White-03.jpg", shelter_id: shelter.id)
 
     visit "/pets/#{pet1.id}"
     click_on "Update"

--- a/spec/features/pets/index_spec.rb
+++ b/spec/features/pets/index_spec.rb
@@ -3,8 +3,8 @@ RSpec.describe 'as a visitor' do
     it 'then I see each Pet in the system including image, name, approximate age, sex, name of shelter' do
 
       shelter = Shelter.create(name: "Braun Farm")
-      pet1 = Pet.create!(name: 'Noodle', approx_age: 3, sex: "M", image: "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/13001403/Australian-Cattle-Dog-On-White-03.jpg", shelter_id: shelter.id, status: 'adoptable' )
-      pet2 = Pet.create!(name: 'Marley', approx_age: 12, sex: "F", image: "", shelter_id: shelter.id, status: 'adoptable')
+      pet1 = Pet.create!(name: 'Noodle', approx_age: 3, sex: "M", image: "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/13001403/Australian-Cattle-Dog-On-White-03.jpg", shelter_id: shelter.id)
+      pet2 = Pet.create!(name: 'Marley', approx_age: 12, sex: "F", image: "", shelter_id: shelter.id)
 
       visit '/pets'
 

--- a/spec/features/pets/show_spec.rb
+++ b/spec/features/pets/show_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe 'as a visitor' do
   before :each do
     @shelter = Shelter.create(name: "Braun Farm")
-    @pet1 = Pet.create(name: 'Noodle', approx_age: 3, sex: "male", description: "description of noodle", image: "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/13001403/Australian-Cattle-Dog-On-White-03.jpg", shelter_id: @shelter.id, status: "adoptable" )
-    @pet2 = Pet.create(name: 'Yoda', approx_age: 3, sex: "male", description: "description of noodle", image: "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/13001403/Australian-Cattle-Dog-On-White-03.jpg", shelter_id: @shelter.id, status: "adoptable" )
+    @pet1 = Pet.create(name: 'Noodle', approx_age: 3, sex: "male", description: "description of noodle", image: "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/13001403/Australian-Cattle-Dog-On-White-03.jpg", shelter_id: @shelter.id )
+    @pet2 = Pet.create(name: 'Yoda', approx_age: 3, sex: "male", description: "description of noodle", image: "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/13001403/Australian-Cattle-Dog-On-White-03.jpg", shelter_id: @shelter.id)
     @application1 = Application.create(name: 'Timmy', address: '123 Street St.', city: 'Denver', state: 'CO', zip: '80218', phone_number: '303-123-4567', reason: 'Because I love animals!')
     ApplicationPet.create(application_id: @application1.id, pet_id: @pet1.id)
   end

--- a/spec/features/shelter_links_spec.rb
+++ b/spec/features/shelter_links_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'as a visitor' do
 
       shelter = Shelter.create(name: "Braun Farm")
 
-      pet1 = Pet.create!(name: 'Noodle', approx_age: 3, sex: "male", description: "description of noodle", image: "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/13001403/Australian-Cattle-Dog-On-White-03.jpg", shelter_id: shelter.id, status: "adoptable" )
+      pet1 = Pet.create!(name: 'Noodle', approx_age: 3, sex: "male", description: "description of noodle", image: "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/13001403/Australian-Cattle-Dog-On-White-03.jpg", shelter_id: shelter.id )
 
 
       visit '/shelters'

--- a/spec/features/shelters/pets_index_spec.rb
+++ b/spec/features/shelters/pets_index_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe 'As a visitor' do
     shelter = Shelter.create!(name: "Braun Farm")
     shelter2 = Shelter.create!(name: "Jax Rescue")
 
-    pet1 = Pet.create!(name: 'Noodle', approx_age: 3, sex: "male", image: "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/13001403/Australian-Cattle-Dog-On-White-03.jpg", shelter_id: shelter.id, status: 'adoptable' )
+    pet1 = Pet.create!(name: 'Noodle', approx_age: 3, sex: "male", image: "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/13001403/Australian-Cattle-Dog-On-White-03.jpg", shelter_id: shelter.id )
 
-    pet2 = Pet.create!(name: 'Marley', approx_age: 12, sex: "female", image: "https://s3-eu-west-1.amazonaws.com/w3.cdn.gpd/gb.pedigree.56/large_e6bfdad9-6951-407b-a11f-bbd0c25bd796.jpg", shelter_id: shelter.id, status: 'adoptable' )
+    pet2 = Pet.create!(name: 'Marley', approx_age: 12, sex: "female", image: "https://s3-eu-west-1.amazonaws.com/w3.cdn.gpd/gb.pedigree.56/large_e6bfdad9-6951-407b-a11f-bbd0c25bd796.jpg", shelter_id: shelter.id)
 
-    pet3 = Pet.create!(name: 'Leo', approx_age: 7, sex: 'male', image: "", shelter_id: shelter2.id, status: 'adoptable')
+    pet3 = Pet.create!(name: 'Leo', approx_age: 7, sex: 'male', image: "", shelter_id: shelter2.id)
 
     visit "/shelters/#{shelter.id}/pets"
 

--- a/spec/models/application_pet_spec.rb
+++ b/spec/models/application_pet_spec.rb
@@ -3,4 +3,28 @@ RSpec.describe ApplicationPet, type: :model do
     it {should belong_to :application}
     it {should belong_to :pet}
   end
+
+  describe '#approve_app, #unapprove' do
+    it 'can change approved status from the default of false, to true' do
+      shelter = Shelter.create(name: "Braun Farm", address: '4242 Farm Rd.', city: 'Eustis', state: 'FL', zip: 33790)
+
+      pet = Pet.create(name: 'Noodle', approx_age: 3, sex: "male", image: "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/13001403/Australian-Cattle-Dog-On-White-03.jpg", shelter_id: shelter.id, status: 'adoptable' )
+
+      app1 = Application.create(name: 'New Application', address: '1234 Tests', city: 'Mayo', state: 'FL', zip: 33499)
+      app2 = Application.create(name: 'Newest Application', address: '1234 Specs', city: 'Bronson', state: 'FL', zip: 33499)
+
+      ap = ApplicationPet.create(application_id: app1.id, pet_id: pet.id)
+      ap2 = ApplicationPet.create(application_id: app2.id, pet_id: pet.id)
+
+      expect(ap.approve).to eq(false)
+      ap.approve_app
+      expect(ap.approve).to eq(true)
+      ap.unapprove
+      expect(ap.approve).to eq(false)
+      ap.toggle_status
+      expect(ap.approve).to eq(true)
+      ap.toggle_status
+      expect(ap.approve).to eq(false)
+    end
+  end
 end

--- a/spec/models/application_pet_spec.rb
+++ b/spec/models/application_pet_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ApplicationPet, type: :model do
     it 'can change approved status from the default of false, to true' do
       shelter = Shelter.create(name: "Braun Farm", address: '4242 Farm Rd.', city: 'Eustis', state: 'FL', zip: 33790)
 
-      pet = Pet.create(name: 'Noodle', approx_age: 3, sex: "male", image: "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/13001403/Australian-Cattle-Dog-On-White-03.jpg", shelter_id: shelter.id, status: 'adoptable' )
+      pet = Pet.create(name: 'Noodle', approx_age: 3, sex: "male", image: "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/13001403/Australian-Cattle-Dog-On-White-03.jpg", shelter_id: shelter.id)
 
       app1 = Application.create(name: 'New Application', address: '1234 Tests', city: 'Mayo', state: 'FL', zip: 33499)
       app2 = Application.create(name: 'Newest Application', address: '1234 Specs', city: 'Bronson', state: 'FL', zip: 33499)

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -31,9 +31,9 @@ RSpec.describe Application do
       expect(ap.approve).to eq(true)
       ap.unapprove
       expect(ap.approve).to eq(false)
-      ap.toggle
+      ap.toggle_status
       expect(ap.approve).to eq(true)
-      ap.toggle
+      ap.toggle_status
       expect(ap.approve).to eq(false)
     end
   end

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Application do
 
       shelter = Shelter.create!(name: "Braun Farm", address: '4242 Farm Rd.', city: 'Eustis', state: 'FL', zip: 33790)
 
-      pet = Pet.create!(name: 'Noodle', approx_age: 3, sex: "male", image: "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/13001403/Australian-Cattle-Dog-On-White-03.jpg", shelter_id: shelter.id, status: 'adoptable' )
+      pet = Pet.create!(name: 'Noodle', approx_age: 3, sex: "male", image: "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/13001403/Australian-Cattle-Dog-On-White-03.jpg", shelter_id: shelter.id)
 
       app1 = Application.create!(name: 'New Application', address: '1234 Tests', city: 'Mayo', state: 'FL', zip: 33499, phone_number: '333444999', reason: 'because')
       app2 = Application.create!(name: 'Newest Application', address: '1234 Specs', city: 'Bronson', state: 'FL', zip: 33499, phone_number: '333444999', reason: 'because')

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -13,4 +13,39 @@ RSpec.describe Application do
     it { should have_many :application_pets }
     it { should have_many(:pets).through(:application_pets) }
   end
+
+  describe '#approve_app' do
+    it 'can change approved status from the default of false, to true' do
+      shelter = Shelter.create(name: "Braun Farm", address: '4242 Farm Rd.', city: 'Eustis', state: 'FL', zip: 33790)
+
+      pet = Pet.create(name: 'Noodle', approx_age: 3, sex: "male", image: "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/13001403/Australian-Cattle-Dog-On-White-03.jpg", shelter_id: shelter.id, status: 'adoptable' )
+
+      app1 = Application.create(name: 'New Application', address: '1234 Tests', city: 'Mayo', state: 'FL', zip: 33499)
+      app2 = Application.create(name: 'Newest Application', address: '1234 Specs', city: 'Bronson', state: 'FL', zip: 33499)
+
+      ap = ApplicationPet.create(application_id: app1.id, pet_id: pet.id)
+      ap2 = ApplicationPet.create(application_id: app2.id, pet_id: pet.id)
+
+      expect(ap.approve).to eq(false)
+      ap.approve_app
+      expect(ap.approve).to eq(true)
+    end
+  end
+
+  describe '#can_be_approved?' do
+    xit 'checks whether it can be approved for given pet by checking if given pet already has another approved application' do
+
+      shelter = Shelter.create(name: "Braun Farm", address: '4242 Farm Rd.', city: 'Eustis', state: 'FL', zip: 33790)
+
+      pet = Pet.create(name: 'Noodle', approx_age: 3, sex: "male", image: "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/13001403/Australian-Cattle-Dog-On-White-03.jpg", shelter_id: shelter.id, status: 'adoptable' )
+
+      app1 = Application.create(name: 'New Application', address: '1234 Tests', city: 'Mayo', state: 'FL', zip: 33499)
+      app2 = Application.create(name: 'Newest Application', address: '1234 Specs', city: 'Bronson', state: 'FL', zip: 33499)
+
+      ap = ApplicationPet.create(application_id: app1.id, pet_id: pet.id)
+      ap2 = ApplicationPet.create(application_id: app2.id, pet_id: pet.id)
+
+
+    end
+  end
 end

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -38,20 +38,23 @@ RSpec.describe Application do
     end
   end
 
-  describe '#can_be_approved?' do
-    xit 'checks whether it can be approved for given pet by checking if given pet already has another approved application' do
+  describe '#find_app_pet & #can_approve' do
+    it 'checks whether it can be approved for given pet by checking if given pet already has another approved application' do
 
-      shelter = Shelter.create(name: "Braun Farm", address: '4242 Farm Rd.', city: 'Eustis', state: 'FL', zip: 33790)
+      shelter = Shelter.create!(name: "Braun Farm", address: '4242 Farm Rd.', city: 'Eustis', state: 'FL', zip: 33790)
 
-      pet = Pet.create(name: 'Noodle', approx_age: 3, sex: "male", image: "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/13001403/Australian-Cattle-Dog-On-White-03.jpg", shelter_id: shelter.id, status: 'adoptable' )
+      pet = Pet.create!(name: 'Noodle', approx_age: 3, sex: "male", image: "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/13001403/Australian-Cattle-Dog-On-White-03.jpg", shelter_id: shelter.id, status: 'adoptable' )
 
-      app1 = Application.create(name: 'New Application', address: '1234 Tests', city: 'Mayo', state: 'FL', zip: 33499)
-      app2 = Application.create(name: 'Newest Application', address: '1234 Specs', city: 'Bronson', state: 'FL', zip: 33499)
+      app1 = Application.create!(name: 'New Application', address: '1234 Tests', city: 'Mayo', state: 'FL', zip: 33499, phone_number: '333444999', reason: 'because')
+      app2 = Application.create!(name: 'Newest Application', address: '1234 Specs', city: 'Bronson', state: 'FL', zip: 33499, phone_number: '333444999', reason: 'because')
 
-      ap = ApplicationPet.create(application_id: app1.id, pet_id: pet.id)
-      ap2 = ApplicationPet.create(application_id: app2.id, pet_id: pet.id)
+      ap = ApplicationPet.create!(application_id: app1.id, pet_id: pet.id)
+      ap2 = ApplicationPet.create!(application_id: app2.id, pet_id: pet.id)
 
+      expect(app1.can_approve(pet)).to eq(true)
+      app1.approve_for(pet)
 
+      expect(app2.can_approve(pet)).to eq(false)
     end
   end
 end

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -14,30 +14,6 @@ RSpec.describe Application do
     it { should have_many(:pets).through(:application_pets) }
   end
 
-  describe '#approve_app, #unapprove' do
-    it 'can change approved status from the default of false, to true' do
-      shelter = Shelter.create(name: "Braun Farm", address: '4242 Farm Rd.', city: 'Eustis', state: 'FL', zip: 33790)
-
-      pet = Pet.create(name: 'Noodle', approx_age: 3, sex: "male", image: "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/13001403/Australian-Cattle-Dog-On-White-03.jpg", shelter_id: shelter.id, status: 'adoptable' )
-
-      app1 = Application.create(name: 'New Application', address: '1234 Tests', city: 'Mayo', state: 'FL', zip: 33499)
-      app2 = Application.create(name: 'Newest Application', address: '1234 Specs', city: 'Bronson', state: 'FL', zip: 33499)
-
-      ap = ApplicationPet.create(application_id: app1.id, pet_id: pet.id)
-      ap2 = ApplicationPet.create(application_id: app2.id, pet_id: pet.id)
-
-      expect(ap.approve).to eq(false)
-      ap.approve_app
-      expect(ap.approve).to eq(true)
-      ap.unapprove
-      expect(ap.approve).to eq(false)
-      ap.toggle_status
-      expect(ap.approve).to eq(true)
-      ap.toggle_status
-      expect(ap.approve).to eq(false)
-    end
-  end
-
   describe '#find_app_pet & #can_approve' do
     it 'checks whether it can be approved for given pet by checking if given pet already has another approved application' do
 

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Application do
     it { should have_many(:pets).through(:application_pets) }
   end
 
-  describe '#approve_app' do
+  describe '#approve_app, #unapprove' do
     it 'can change approved status from the default of false, to true' do
       shelter = Shelter.create(name: "Braun Farm", address: '4242 Farm Rd.', city: 'Eustis', state: 'FL', zip: 33790)
 
@@ -29,6 +29,12 @@ RSpec.describe Application do
       expect(ap.approve).to eq(false)
       ap.approve_app
       expect(ap.approve).to eq(true)
+      ap.unapprove
+      expect(ap.approve).to eq(false)
+      ap.toggle
+      expect(ap.approve).to eq(true)
+      ap.toggle
+      expect(ap.approve).to eq(false)
     end
   end
 


### PR DESCRIPTION
@NickEdwin 
I'm afraid to merge anything else to master until we figure out why half the tests are failing. Lets talk about that tomorrow.

As for this PR - 
- removed pet status column in Pets table and added `approve:boolean` column to `ApplicationPets` table 
- removed all references to `status` on all Pet objects created for testing and seeding purposes so tests won't break
- Created `applications#update` to deal with functionality relating to approve/disapprove applications
- the last one is possible by a handful of new methods under both `Application` and `ApplicationPet` models
- there are tests for most of these methods in model specs. I think i'm missing a specific test for application#can_approve and application#can_unapprove.

- User Story #24 is FINALLY complete and working.