### PR TITLE
Complete extension 37 - list app status next to pet name on Favorites…

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,7 +594,7 @@ It is a link to their application show page
 ```
 User Story 37, List of Pets with Approved Applications
 
-[ ] done
+[X] done
 
 As a visitor
 After an application has been approved for one or more pets

--- a/app/assets/stylesheets/main.css
+++ b/app/assets/stylesheets/main.css
@@ -150,6 +150,18 @@ main {
 	align-content: baseline;
 }
 
+.app-names .options {
+	margin-top: 0px;
+}
+
+.app-names {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  margin: 0px 0 20px 0px;
+	align-content: baseline;
+}
+
 #pets-index {
   display: flex;
   justify-content: flex-start;

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -48,6 +48,11 @@
       <% @pets.each do |pet| %>
         <div class='app-names'>
           <h4><%= link_to "#{pet.name}", "/pets/#{pet.id}", class: 'list-name' %></h4>
+          <span class='options'>
+            <% if pet.status == :pending %>
+              <span>(approved)</span>
+            <% end %>
+          </span>
         </div>
       <% end %>
     <% else %>

--- a/spec/features/favorites/index_spec.rb
+++ b/spec/features/favorites/index_spec.rb
@@ -3,7 +3,6 @@ RSpec.describe "as a visitor", type: :feature do
     @shelter = Shelter.create!({name: "Braun Farm", address: "1234 NW 10th St.", city: "Gainesville", state: "FL", zip: 32609})
     @pet1 = Pet.create(name: 'Noodle', approx_age: 3, sex: "male", description: "description of noodle", image: "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/13001403/Australian-Cattle-Dog-On-White-03.jpg", shelter_id: @shelter.id)
     @pet2 = Pet.create(name: 'Yoda', approx_age: 4, sex: "female", description: "This is a cat.", image: "https://static.toiimg.com/photo/msid-67586673/67586673.jpg?3918697", shelter_id: @shelter.id)
-
   end
 
   describe 'view favorites index' do
@@ -103,6 +102,21 @@ RSpec.describe "as a visitor", type: :feature do
       expect(page).to have_content("#{@pet1.name}")
       expect(page).to have_content("#{@pet2.name}")
       expect(page).to have_content("You have no favorite pets.")
+    end
+
+    it 'shows application status next to Pet name under \'pets with applications\' section' do
+
+      application1 = Application.create!(name: 'Timmy', address: '123 Street St.', city: 'Denver', state: 'CO', zip: '80218', phone_number: '303-123-4567', reason: 'Because I love animals!')
+      ApplicationPet.create!(application_id: application1.id, pet_id: @pet1.id)
+
+      application1.approve_for(@pet1)
+      visit "/favorites"
+      save_and_open_page
+
+      within('#list-section') do
+        expect(page).to have_content('Noodle')
+        expect(page).to have_content('(approved)')
+      end
     end
   end
 end


### PR DESCRIPTION
-extension #37 done. I added an `(approved)` next to the pet name if there is an approved application on file. 
(this is on the Favorites page)